### PR TITLE
Update pottery.lua

### DIFF
--- a/mods/tech/pottery.lua
+++ b/mods/tech/pottery.lua
@@ -66,7 +66,7 @@ local function water_pot(pos)
 		elseif (name_a == "nodes_nature:ice" or
 			name_a == "nodes_nature:snow_block" or
 			name_a == "nodes_nature:freshwater_source" ) then
-			if climate.can_thaw(posa) then
+			if climate.get_point_temp(pos) > 0 then
 				minetest.set_node(pos, {name = "tech:clay_water_pot_freshwater"})
 				minetest.remove_node(posa)
 				return


### PR DESCRIPTION
Change temperature position check from roof to the water pot itself. Atm when placing a clay water pot on a fire, the game starts a 30-60 timer then checks if the pot has ice/snow/water over it then calls climate.can_thaw which checks the temperature of the block found above the ice/snow/water. If you have a stack of fireblock, water pot, snow, hut roof,outside freezing cold, the game decides to check the temperature of the roof to decide if melting happens. Changes will make sure the temp check happens at the clay water pot itself