### PR TITLE
Added translation glue for minimal and artifacts/transporters

### DIFF
--- a/mods/artifacts/init.lua
+++ b/mods/artifacts/init.lua
@@ -2,6 +2,10 @@
 --ARTIFACTS
 ------------------------------------
 artifacts = {}
+artifacts.S = minetest.get_translator("artifacts")
+artifacts.FS = function(...)
+	return minetest.formspec_escape(artifacts.S(...))
+end
 
 local modpath = minetest.get_modpath('artifacts')
 

--- a/mods/artifacts/transporter.lua
+++ b/mods/artifacts/transporter.lua
@@ -14,15 +14,16 @@ Components
 -stabilizer: locks onto actual location, not just general area
 -focalizer: increases range to full distance
 
--locator ley: allows linking (item)
+-transporter key: allows linking (item)
 
 Components must be 1 block radius around the pad. Above pad must be kept clear.
 Only need one of each
 
 ]]
 
-
-local S = minetest.get_translator("transporter")
+artifacts = artifacts
+local S = artifacts.S()
+local FS = artifacts.FS()
 ------------------------------------
 local rand = math.random
 --minimum distance transporters muct be apart (nodes)

--- a/mods/minimal/init.lua
+++ b/mods/minimal/init.lua
@@ -16,6 +16,10 @@ minimal = {
 
 }
 
+minimal.S = minetest.get_translator("minimal")
+minimal.FS = function(...)
+	return minetest.formspec_escape(minimal.S(...))
+end
 
 dofile(minetest.get_modpath('minimal')..'/item_names.lua')
 dofile(minetest.get_modpath('minimal')..'/settingswarn.lua')


### PR DESCRIPTION
Added S() and FS() functions to minimal and artifacts and corrected
transporters to use local S=artifacts.S().  Originally was using
"transporters" when should have been using "artifacts" for the local S()