### PR TITLE
Bug fix - Transporter power cores wont charge

### DIFF
--- a/mods/artifacts/transporter.lua
+++ b/mods/artifacts/transporter.lua
@@ -376,7 +376,7 @@ local function transporter_power_rightclick(pos, node, player, itemstack, pointe
 	itemstack:take_item()
 	-- XXX shouldn't be clobbering existing info text
 	meta:set_string("infotext", description .. "\n" .. S("Owned by @1", pn))
-	minetest.swap_node(pos, {name=swap_a})
+	minimal.switch_node(pos, {name=swap_a})
 	if pInv:room_for_item("main", new) then
 	   pInv:add_item("main", new)
 	   return itemstack


### PR DESCRIPTION
Power cores wont charge after swapping power between them.  Replaced
minetest.swap_node() with minimal.switch_node() to resolve.  Timers
weren't starting before.