### PR TITLE
Fix loose bricks stack size to 6 instead of 4

### DIFF
--- a/mods/tech/bricks_and_mortar.lua
+++ b/mods/tech/bricks_and_mortar.lua
@@ -348,7 +348,7 @@ end
 minetest.register_node('tech:loose_brick_unfired', {
 	description = S('Loose Bricks (unfired)'),
 	tiles = {"nodes_nature_clay.png"},
-	stack_max = minimal.stack_max_bulky *2,
+	stack_max = minimal.stack_max_bulky *3,
   drawtype = "nodebox",
 	paramtype = "light",
   paramtype2 = "facedir",


### PR DESCRIPTION
Crafting recipe is for 6.  causing lost bricks when moving them around
because of stack size limits.