### PR TITLE
Caluculate the av_depth_factor based on configured av_temp

### DIFF
--- a/mods/climate/temperature.lua
+++ b/mods/climate/temperature.lua
@@ -243,7 +243,9 @@ local adjust_active_temp = function(pos, temp)
    --Underground
    if pos.y < av_temp_depth then
       --average temp, heating under the earth. ~ 25C/km
-      temp = -0.025*pos.y + av_temp
+      --calculate depth factor based on temp of 40 at -1000
+      local av_depth_factor = (40 - av_temp) / -1000
+      temp = av_depth_factor*pos.y + av_temp
       temp = adjust_for_heatable(pos, name, temp)
       return temp
    end

--- a/mods/climate/temperature.lua
+++ b/mods/climate/temperature.lua
@@ -244,7 +244,7 @@ local adjust_active_temp = function(pos, temp)
    if pos.y < av_temp_depth then
       --average temp, heating under the earth. ~ 25C/km
       --calculate depth factor based on temp of 40 at -1000
-      local av_depth_factor = (40 - av_temp) / -1000
+      local av_depth_factor = (40 - av_temp) / (-1000-av_temp_depth)
       temp = av_depth_factor*pos.y + av_temp
       temp = adjust_for_heatable(pos, name, temp)
       return temp

--- a/mods/climate/temperature.lua
+++ b/mods/climate/temperature.lua
@@ -245,7 +245,7 @@ local adjust_active_temp = function(pos, temp)
       --average temp, heating under the earth. ~ 25C/km
       --calculate depth factor based on temp of 40 at -1000
       local av_depth_factor = (40 - av_temp) / (-1000-av_temp_depth)
-      temp = av_depth_factor*pos.y + av_temp
+      temp = av_depth_factor*(pos.y-av_temp_depth) + av_temp
       temp = adjust_for_heatable(pos, name, temp)
       return temp
    end


### PR DESCRIPTION
The tempurature	at depth -1000 was 40c in the original formula
of -0.025*pos.y + av_temp.  Replacing the -0.025 with av_depth_factor
calculated as 40-av_temp/-1000.