### PR TITLE
Add Mt Meru to Rings

### DIFF
--- a/mods/rings/README.txt
+++ b/mods/rings/README.txt
@@ -1,0 +1,9 @@
+Rings: surface megastructures
+=============================
+Adds broken rings structures scattered around the map, and a tall tower in the centre of the map.
+
+
+Authors of source code
+----------------------
+Rings by Skamiz
+Meru adapted from Mount Meru by Paramat (WTFPL)

--- a/mods/rings/init.lua
+++ b/mods/rings/init.lua
@@ -48,6 +48,7 @@ minetest.register_node("rings:moon_glass", {
 	drop = "artifacts:moon_glass",
 })
 
+dofile(minetest.get_modpath("rings") .. "/meru.lua")
 
 local c_ring = minetest.get_content_id("rings:antiquorium")
 local c_ring_i = minetest.get_content_id("rings:moon_glass") -- TODO: replace this with a glowing material

--- a/mods/rings/meru.lua
+++ b/mods/rings/meru.lua
@@ -1,0 +1,177 @@
+-- Parameters
+--[[
+Reducing noise to zero at the center creates a perfect spike as a summit. Constant noise throughout often creates floating islands at the summit. Choosing zero noise throughout creates a smooth geometric conical shape. There is a parameter CONVEX to control whether the basic conical structure bulges outwards or is pinched inwards in the middle.
+
+]]
+
+local COORD = false -- Print tower co-ordinates to terminal (cheat)
+
+local XMIN = -128 -- Area for random spawn
+local XMAX = 128
+local ZMIN = -128
+local ZMAX = 128
+local YBASE = -32 --[[originally -32 hardcoded, not as a variable. Changing this doesn't successfully alter base height.]]
+
+local BASRAD = 128 -- Average radius at y = YBASE
+local HEIGHT = 640 -- Approximate height measured from y = YBASE
+local CONVEX = 0.8 -- Convexity. <1 = concave, 1 = conical, >1 = convex
+local VOID = 0.8 -- Void threshold. Controls size of central void
+local NOISYRAD = 0.05 -- Noisyness of structure at base radius.
+						-- 0 = smooth geometric form, 0.3 = noisy.
+local NOISYCEN = 0 -- Noisyness of structure at centre
+local FISOFFBAS = 0.03 -- Fissure noise offset at base,
+						-- controls size of fissure entrances on outer surface.
+local FISOFFTOP = 0.06 -- Fissure noise offset at top
+local FISEXPBAS = 0.6 -- Fissure expansion rate under surface at base
+local FISEXPTOP = 1.4 -- Fissure expansion rate under surface at top
+
+-- 3D noise for primary structure
+
+local np_structure = {
+	offset = 0,
+	scale = 1,
+	spread = {x = 64, y = 64, z = 64},
+	seed = 46893,
+	octaves = 5,
+	persist = 0.5
+}
+
+-- 3D noise for fissures
+
+local np_fissure = {
+	offset = 0,
+	scale = 1,
+	spread = {x = 24, y = 24, z = 24},
+	seed = 92940980987,
+	octaves = 4,
+	persist = 0.6
+}
+
+-- 2D noise for biome. (controls block type)
+
+local np_biome = {
+	offset = 0,
+	scale = 1,
+	spread = {x = 64, y = 64, z = 64},
+	seed = 9130,
+	octaves = 3,
+	persist = 0.7
+}
+
+-- Stuff
+
+local cxmin = math.floor((XMIN + 32) / 80) -- limits in chunk co-ordinates
+local czmin = math.floor((ZMIN + 32) / 80)
+local cxmax = math.floor((XMAX + 32) / 80)
+local czmax = math.floor((ZMAX + 32) / 80)
+local cxav = (cxmin + cxmax) / 2 -- spawn area midpoint in chunk co-ordinates
+local czav = (czmin + czmax) / 2
+local xnom = (cxmax - cxmin) / 4 -- noise multipliers
+local znom = (czmax - czmin) / 4
+
+
+
+-- Initialize noise objects to nil
+
+local nobj_structure = nil
+local nobj_fissure = nil
+local nobj_biome = nil
+
+-- On generated function
+
+minetest.register_on_generated(function(minp, maxp, seed)
+	if maxp.x < XMIN or minp.x > XMAX
+	or maxp.z < ZMIN or minp.z > ZMAX then
+		return
+	end
+
+	local locnoise = minetest.get_perlin(5839090, 2, 0.5, 3)
+	local noisex = locnoise:get2d({x = 31, y = 23})
+	local noisez = locnoise:get2d({x = 17, y = 11})
+	local cx = cxav + math.floor(noisex * xnom) -- chunk co ordinates
+	local cz = czav + math.floor(noisez * znom)
+	local merux = 80 * cx + 8
+	local meruz = 80 * cz + 8
+	if COORD then
+		print ("[meru] at x " .. merux .. " z " .. meruz)
+	end
+	if minp.x < merux - 120 or minp.x > merux + 40
+	or minp.z < meruz - 120 or minp.z > meruz + 40
+	or minp.y < YBASE or minp.y > HEIGHT * 1.2 then
+		return
+	end
+
+	local t0 = os.clock()
+	local x0 = minp.x
+	local y0 = minp.y
+	local z0 = minp.z
+	local x1 = maxp.x
+	local y1 = maxp.y
+	local z1 = maxp.z
+	
+	local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
+	local area = VoxelArea:new{MinEdge = emin, MaxEdge = emax}
+	local data = vm:get_data()
+
+	local c_stone = minetest.get_content_id("rings:antiquorium")
+	local c_destone = minetest.get_content_id("rings:moon_glass")
+
+	local sidelen = x1 - x0 + 1
+	local chulens3d = {x = sidelen, y = sidelen, z = sidelen}
+	local chulens2d = {x = sidelen, y = sidelen, z = 1}
+	local minpos3d = {x = x0, y = y0, z = z0}
+
+	nobj_structure = nobj_structure or minetest.get_perlin_map(np_structure, chulens3d)
+	nobj_fissure = nobj_fissure or minetest.get_perlin_map(np_fissure, chulens3d)
+	nobj_biome = nobj_biome or minetest.get_perlin_map(np_biome, chulens2d)
+
+	local nvals_structure = nobj_structure:get3dMap_flat(minpos3d)
+	local nvals_fissure = nobj_fissure:get3dMap_flat(minpos3d)
+	local nvals_biome = nobj_biome:get2dMap_flat({x = x0 + 150, y = z0 + 50})
+
+	local nixyz = 1 -- 3D noise index
+	local nixz = 1 -- 2D noise index
+	for z = z0, z1 do
+		for y = y0, y1 do
+			local vi = area:index(x0, y, z)
+			for x = x0, x1 do
+				local n_structure = nvals_structure[nixyz]
+				local radius = ((x - merux) ^ 2 + (z - meruz) ^ 2) ^ 0.5
+				local deprop = (BASRAD - radius) / BASRAD -- radial depth proportion
+				local noisy = NOISYRAD + deprop * (NOISYCEN - NOISYRAD)
+				local heprop = ((y + 32) / HEIGHT) -- height proportion
+				local offset = deprop - heprop ^ CONVEX
+				local n_offstructure = n_structure * noisy + offset
+				if n_offstructure > 0 and n_offstructure < VOID then
+					local n_absfissure = math.abs(nvals_fissure[nixyz])
+					local fisoff = FISOFFBAS + heprop * (FISOFFTOP - FISOFFBAS)
+					local fisexp = FISEXPBAS + heprop * (FISEXPTOP - FISEXPBAS)
+					if n_absfissure - n_offstructure * fisexp - fisoff > 0 then
+						local n_biome = nvals_biome[nixz]
+						local desert = n_biome > 0.45
+						or math.random(0,10) > (0.45 - n_biome) * 100
+						if desert then
+							data[vi] = c_destone
+						else
+							data[vi] = c_stone
+						end
+					end
+				end
+
+				nixyz = nixyz + 1
+				nixz = nixz + 1
+				vi = vi + 1
+			end
+			nixz = nixz - sidelen
+		end
+		nixz = nixz + sidelen
+	end
+
+	vm:set_data(data)
+	vm:set_lighting({day = 0, night = 0})
+	vm:calc_lighting()
+	vm:write_to_map(data)
+
+	local chugent = math.ceil((os.clock() - t0) * 1000)
+	print ("[meru] " .. chugent .. " ms")
+end)


### PR DESCRIPTION
This is something I'd been thinking of adding for a while. Thought I'd try it out, as an experiment.

Adapts Paramats "Mount Meru" to add a giant tower at the centre of the map. This is an awesome "Big Dumb Object" which adds a fantastic central landmark to the map.

I've got it good enough to see that this could be worth having. It's not ready to go straight into the game yet. This is as far as I have time to take it.

Remaining issues
- players can spawn inside blocks
- players can spawn inside the central void without always being able to find a way out
- looks strange in forest biomes, trees spawning inside the cracks. Might be nice to clear a barren zone around the structure... somehow.
- Spawning inside this thing is confusing, it feels like it fills the whole world. On the other hand, that could work. This could be the Gateway. Your first task is to find a way out of it, and emerge into the wide open spaces outside.
- can't figure out how to set the base height, seems locked at -32m, which means it floats in water (ideally I'd want it going to -1000m right to the base of the city). Megamorph seems to successfully carve out space from it, so they might be compatible.
- Many variables for tweaking to get the ideal shape.
- uses 2D noise to control moonglass vs antiquorium. Originally made to match to MT game biomes? Might be better as 3D noise?
- it's cave system doesn't clear regular mapgen, so gets clogged up with random bits of rock from hills.
- I've done zero playtesting. This would probably give a garunteed shelter of enormous size to all new players.
- Maybe add a setting to disable it until properly ready.