### PR TITLE
Added support for combining small_wood_fire_ext

### DIFF
--- a/mods/minimal/utility.lua
+++ b/mods/minimal/utility.lua
@@ -26,7 +26,7 @@ function minimal.safe_landing_spot(pos)
 				      def_top.walkable == true ) then
       return false -- loaded a solid node
    end
-   if dest_bot.name ~= "ignore" and ( _bot and
+   if dest_bot.name ~= "ignore" and ( def_bot and
 				      def_bot.walkable == true ) then
       return false
    end

--- a/mods/minimal/utility.lua
+++ b/mods/minimal/utility.lua
@@ -50,20 +50,23 @@ function minimal.safe_landing_spot(pos)
    end
 end
 
-function minimal.slabs_rightclick_combine(pos, node, clicker, itemstack, pointed_thing)
-print("here")
-	print(dump(node))
-
+-- Call in on_rightclick wrapper like this:
+-- on_rightclick = function (pos, node, clicker, itemstack, pointed_thing) 
+--     minimal.slabs_combine(pos,node,itemstack,'tech:large_wood_fire_ext')
+-- end
+function minimal.slabs_combine(pos, node, itemstack, swap_node)
 	if itemstack:get_name() == node.name then
 		-- combine slabs
 		local stack_meta = itemstack:get_meta()
-		local pt_meta = minetest.get_meta(pos)
-		local fuel = pt_meta:get_int("fuel") + stack_meta:get_int("fuel")
-		pt_meta:set_int("fuel",fuel)
-		swap_node = 'tech:large_wood_fire_ext'
+		local fuel = stack_meta:get_int("fuel")
+		if fuel ~= nil then
+			local pt_meta = minetest.get_meta(pos)
+			fuel = fuel + pt_meta:get_int("fuel")
+			pt_meta:set_int("fuel",fuel)
+		end
 		minimal.switch_node(pos,{name=swap_node})
 		itemstack:take_item()
 		return itemstack
 	end
-	return false
 end
+

--- a/mods/minimal/utility.lua
+++ b/mods/minimal/utility.lua
@@ -26,7 +26,7 @@ function minimal.safe_landing_spot(pos)
 				      def_top.walkable == true ) then
       return false -- loaded a solid node
    end
-   if dest_bot.name ~= "ignore" and ( def_bot and
+   if dest_bot.name ~= "ignore" and ( _bot and
 				      def_bot.walkable == true ) then
       return false
    end
@@ -48,4 +48,22 @@ function minimal.safe_landing_spot(pos)
    else
       return true
    end
+end
+
+function minimal.slabs_rightclick_combine(pos, node, clicker, itemstack, pointed_thing)
+print("here")
+	print(dump(node))
+
+	if itemstack:get_name() == node.name then
+		-- combine slabs
+		local stack_meta = itemstack:get_meta()
+		local pt_meta = minetest.get_meta(pos)
+		local fuel = pt_meta:get_int("fuel") + stack_meta:get_int("fuel")
+		pt_meta:set_int("fuel",fuel)
+		swap_node = 'tech:large_wood_fire_ext'
+		minimal.switch_node(pos,{name=swap_node})
+		itemstack:take_item()
+		return itemstack
+	end
+	return false
 end

--- a/mods/nodes_nature/liquids.lua
+++ b/mods/nodes_nature/liquids.lua
@@ -209,7 +209,10 @@ minetest.register_node("nodes_nature:snow", {
 	temp_effect_max = 0,
 	groups = {crumbly = 3, falling_node = 1, temp_effect = 1, temp_pass = 1, puts_out_fire = 1, fall_damage_add_percent = -25},
 	sounds = nodes_nature.node_sound_snow_defaults(),
-	on_use = exile_eatdrink
+	on_use = exile_eatdrink,
+	on_rightclick = function (pos,node,clicker,itemstack,pointed_thing)
+		minimal.slabs_combine(pos,node,itemstack,'nodes_nature:snow_block')
+	end,
 })
 
 minetest.register_node("nodes_nature:snow_block", {

--- a/mods/tech/earthen_building.lua
+++ b/mods/tech/earthen_building.lua
@@ -288,6 +288,12 @@ stairs.register_stair_and_slab(
 	nodes_nature.node_sound_leaves_defaults()
 )
 
+minetest.override_item('stairs:slab_thatch', {
+	on_rightclick = function (pos,node,clicker,itemstack,pointed_thing)
+		minimal.slabs_combine(pos,node,itemstack,'tech:thatch')
+	end,
+})
+
 
 
 ---------------------------------------

--- a/mods/tech/earthen_building.lua
+++ b/mods/tech/earthen_building.lua
@@ -288,11 +288,6 @@ stairs.register_stair_and_slab(
 	nodes_nature.node_sound_leaves_defaults()
 )
 
-minetest.override_item('stairs:slab_thatch', {
-	on_rightclick = function (pos,node,clicker,itemstack,pointed_thing)
-		minimal.slabs_combine(pos,node,itemstack,'tech:thatch')
-	end,
-})
 
 
 

--- a/mods/tech/fires.lua
+++ b/mods/tech/fires.lua
@@ -238,6 +238,10 @@ minetest.register_node("tech:charcoal", {
 		minetest.set_node(pos, {name = "tech:small_charcoal_fire"})
 		minetest.check_for_falling(pos)
 	end,
+	on_rightclick = function (pos,node,clicker,itemstack,pointed_thing) 
+		minimal.slabs_combine(pos,node,itemstack,'tech:charcoal_block')
+	end,
+
 })
 
 
@@ -287,6 +291,9 @@ minetest.register_node('tech:small_wood_fire_unlit', {
 	paramtype = "light",
 	groups = {oddly_breakable_by_hand = 3, choppy = 3, falling_node = 1, flammable = 1},
 	sounds = nodes_nature.node_sound_wood_defaults(),
+	on_rightclick = function (pos,node,clicker,itemstack,pointed_thing) 
+		minimal.slabs_combine(pos,node,itemstack,'tech:large_wood_fire_unlit')
+	end,
 	on_burn = function(pos)
 		minetest.set_node(pos, {name = "tech:small_wood_fire"})
 		minetest.check_for_falling(pos)
@@ -724,7 +731,6 @@ local after_place_fire = function(pos, placer, itemstack, pointed_thing)
 	end
 end
 
-
 -- wood fires
 minetest.register_node('tech:small_wood_fire_ext', {
 	description = S('Small Wood Fire (extinguished)'),
@@ -740,8 +746,11 @@ minetest.register_node('tech:small_wood_fire_ext', {
 	sounds = nodes_nature.node_sound_dirt_defaults(),
 
 	on_dig = on_dig_fire,
+	on_rightclick = function (pos,node,clicker,itemstack,pointed_thing)
+		minimal.slabs_combine(pos,node,itemstack,'tech:large_wood_fire_ext')
+	end,
 	after_place_node = after_place_fire,
-	on_rightclick = minimal.slab_rightclick_combine,
+
 	on_burn = function(pos)
 	   inferno.ignite(pos)
 	end,
@@ -778,7 +787,9 @@ minetest.register_node('tech:small_charcoal_fire_ext', {
 	groups = {crumbly = 3, oddly_breakable_by_hand = 1, falling_node = 1,
 		  temp_pass = 1, flammable = 3},
 	sounds = nodes_nature.node_sound_dirt_defaults(),
-
+	on_rightclick = function (pos,node,clicker,itemstack,pointed_thing) 
+		minimal.slabs_combine(pos,node,itemstack,'tech:large_charcoal_fire_ext')
+	end,
 	on_dig = on_dig_fire,
 	after_place_node = after_place_fire,
 	on_burn = function(pos)

--- a/mods/tech/fires.lua
+++ b/mods/tech/fires.lua
@@ -716,11 +716,28 @@ end
 
 --set saved fuel
 local after_place_fire = function(pos, placer, itemstack, pointed_thing)
+	local fuel = 0
+	local swap_node = nil
+	if itemstack:get_name() == 'tech:small_wood_fire_ext' then
+		-- combine extinquished small fires to a large fire
+		local pt_pos = minetest.get_pointed_thing_position(pointed_thing)
+		local pt_name = minetest.get_node(pt_pos).name
+		local pt_meta = nil
+		if pt_name == 'tech:small_wood_fire_ext' then
+			pt_meta = minetest.get_meta(pt_pos)
+			fuel = pt_meta:get_int("fuel") or 0
+			minetest.remove_node(pt_pos)
+			swap_node = 'tech:large_wood_fire_ext'
+		end
+	end
 	local meta = minetest.get_meta(pos)
 	local stack_meta = itemstack:get_meta()
-	local fuel = stack_meta:get_int("fuel")
+	fuel = fuel + stack_meta:get_int("fuel")
 	if fuel >0 then
 		meta:set_int("fuel", fuel)
+	end
+	if swap_node then
+		minimal.switch_node(pos,{name=swap_node})
 	end
 end
 

--- a/mods/tech/fires.lua
+++ b/mods/tech/fires.lua
@@ -716,28 +716,11 @@ end
 
 --set saved fuel
 local after_place_fire = function(pos, placer, itemstack, pointed_thing)
-	local fuel = 0
-	local swap_node = nil
-	if itemstack:get_name() == 'tech:small_wood_fire_ext' then
-		-- combine extinquished small fires to a large fire
-		local pt_pos = minetest.get_pointed_thing_position(pointed_thing)
-		local pt_name = minetest.get_node(pt_pos).name
-		local pt_meta = nil
-		if pt_name == 'tech:small_wood_fire_ext' then
-			pt_meta = minetest.get_meta(pt_pos)
-			fuel = pt_meta:get_int("fuel") or 0
-			minetest.remove_node(pt_pos)
-			swap_node = 'tech:large_wood_fire_ext'
-		end
-	end
 	local meta = minetest.get_meta(pos)
 	local stack_meta = itemstack:get_meta()
-	fuel = fuel + stack_meta:get_int("fuel")
+	local fuel = stack_meta:get_int("fuel")
 	if fuel >0 then
 		meta:set_int("fuel", fuel)
-	end
-	if swap_node then
-		minimal.switch_node(pos,{name=swap_node})
 	end
 end
 
@@ -758,6 +741,7 @@ minetest.register_node('tech:small_wood_fire_ext', {
 
 	on_dig = on_dig_fire,
 	after_place_node = after_place_fire,
+	on_rightclick = minimal.slab_rightclick_combine,
 	on_burn = function(pos)
 	   inferno.ignite(pos)
 	end,


### PR DESCRIPTION
Combines the fule value of two small_wood_fire_ext blocks and replaces
it with a large_wood_fire_ext when you place one while pointing at
another.

error in naming branch.  combines small_wood_fire_ext for making charcoal