### PR TITLE
Option to enable double click to eat

### DIFF
--- a/doc/groups.txt
+++ b/doc/groups.txt
@@ -8,6 +8,7 @@ slippery
 falling_node
 attached_node
 craftedby - Add creator meta data to node; used for crafted by labels and keys
+edible - Nodes that are edible - auto adds on_use callbacks to eat
 `nobones`: Don't put this item into bones piles. e.g. crafting spots
 		Note: This destroys the item upon player death
 

--- a/mods/animals/darkasthaan.lua
+++ b/mods/animals/darkasthaan.lua
@@ -132,9 +132,8 @@ minetest.register_node("animals:darkasthaan_eggs", {
 		type = "fixed",
 		fixed = {-0.125, -0.5, -0.125,  0.125, -0.375, 0.125},
 	},
-	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1},
+	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1, temp_pass = 1, edible = 1},
 	sounds = nodes_nature.node_sound_defaults(),
-	on_use = exile_eatdrink,
 	on_construct = function(pos)
 		minetest.get_node_timer(pos):start(math.random(egg_timer,egg_timer*2))
 	end,

--- a/mods/animals/gundu.lua
+++ b/mods/animals/gundu.lua
@@ -207,9 +207,8 @@ minetest.register_node("animals:gundu_eggs", {
 	description = S('Gundu Eggs'),
 	tiles = {"animals_gundu_eggs.png"},
 	stack_max = minimal.stack_max_bulky,
-	groups = {snappy = 3},
+	groups = {snappy = 3, edible = 1},
 	sounds = nodes_nature.node_sound_defaults(),
-	on_use = exile_eatdrink,
 	on_construct = function(pos)
 		minetest.get_node_timer(pos):start(math.random(egg_timer,egg_timer*2))
 	end,

--- a/mods/animals/impethu.lua
+++ b/mods/animals/impethu.lua
@@ -147,9 +147,8 @@ minetest.register_node("animals:impethu_eggs", {
 		type = "fixed",
 		fixed = {-0.08, -0.5, -0.08,  0.08, -0.4375, 0.08},
 	},
-	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1},
+	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1, temp_pass = 1, edible = 1},
 	sounds = nodes_nature.node_sound_defaults(),
-	on_use = exile_eatdrink,
 	on_construct = function(pos)
 		minetest.get_node_timer(pos):start(math.random(egg_timer,egg_timer*2))
 	end,

--- a/mods/animals/kubwakubwa.lua
+++ b/mods/animals/kubwakubwa.lua
@@ -132,9 +132,8 @@ minetest.register_node("animals:kubwakubwa_eggs", {
 		type = "fixed",
 		fixed = {-0.0625, -0.5, -0.0625,  0.0625, -0.375, 0.0625},
 	},
-	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1},
+	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1, temp_pass = 1, edible = 1},
 	sounds = nodes_nature.node_sound_defaults(),
-	on_use = exile_eatdrink,
 	on_construct = function(pos)
 		minetest.get_node_timer(pos):start(math.random(egg_timer,egg_timer*2))
 	end,

--- a/mods/animals/pegasun.lua
+++ b/mods/animals/pegasun.lua
@@ -384,9 +384,8 @@ minetest.register_node("animals:pegasun_eggs", {
 		type = "fixed",
 		fixed = {-0.125, -0.5, -0.125,  0.125, -0.125, 0.125},
 	},
-	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1},
+	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1, edible = 1},
 	sounds = nodes_nature.node_sound_defaults(),
-	on_use = exile_eatdrink,
 	on_construct = function(pos)
 		minetest.get_node_timer(pos):start(math.random(egg_timer,egg_timer*2))
 	end,

--- a/mods/animals/sarkamos.lua
+++ b/mods/animals/sarkamos.lua
@@ -129,9 +129,8 @@ minetest.register_node("animals:sarkamos_eggs", {
 	description = S('Sarkamos Eggs'),
 	tiles = {"animals_gundu_eggs.png"},
 	stack_max = minimal.stack_max_bulky,
-	groups = {snappy = 3},
+	groups = {snappy = 3, edible = 1},
 	sounds = nodes_nature.node_sound_defaults(),
-	on_use = exile_eatdrink,
 	on_construct = function(pos)
 		minetest.get_node_timer(pos):start(math.random(egg_timer,egg_timer*2))
 	end,

--- a/mods/animals/sneachan.lua
+++ b/mods/animals/sneachan.lua
@@ -165,9 +165,8 @@ minetest.register_node("animals:sneachan_eggs", {
 		type = "fixed",
 		fixed = {-0.08, -0.5, -0.08,  0.08, -0.4375, 0.08},
 	},
-	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1},
+	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, flammable = 1, temp_pass = 1, edible = 1},
 	sounds = nodes_nature.node_sound_defaults(),
-	on_use = exile_eatdrink,
 	on_construct = function(pos)
 		minetest.get_node_timer(pos):start(math.random(egg_timer,egg_timer*2))
 	end,

--- a/mods/health/food.lua
+++ b/mods/health/food.lua
@@ -36,51 +36,7 @@ local function do_food_harm(user, nodename)
    end
 end
 
-function exile_eatdrink_playermade(itemstack, user)
-   local imeta = itemstack:get_meta()
-   local pname = user:get_player_name()
-   local t = minetest.deserialize(imeta:get_string("eat_value"))
-   if t == nil then minetest.log("warning", pname..
-				    " ate an invalid food of type "..
-				    itemstack:get_name())
-      return
-   end
-   return HEALTH.use_item(itemstack, user, t[1], t[2], t[3], t[4], t[5], t[6])
-end
-
-function exile_eatdrink(itemstack, user)
-   local name = itemstack:get_name()
-
-   if minetest.registered_aliases[name] then
-      name = minetest.registered_aliases[name]
-   end
-   if not food_table[name] then
-      minetest.chat_send_player(user:get_player_name(),
-				S("This is inedible."))
-      return
-   end
-   do_food_harm(user, name)
-   local t = food_table[name]
-   return HEALTH.use_item(itemstack, user, t[1], t[2], t[3], t[4], t[5], t[6])
-end
-
 local __eat_click_settings_cache = {}
-function single_click_eat(pname, user)
-	local epoch = os.time()
-	local cache = __eat_click_settings_cache
-	if not cache[pname] then
-		local pmeta = user:get_meta()
-		local eat2x = pmeta:get_string("conf_eat2x") or minetest.settings:get('exile_eat_doubleclick') or 'false'
-		if eat2x == 'true' then
-			eat2x = true
-		else 
-			eat2x = false
-		end
-		cache[pname] = not eat2x
-	end
-	return cache[pname]
-end
-
 minetest.register_chatcommand("eat2x", {
         params = "true or false",
         description = "Toggles double-click to eat",
@@ -107,21 +63,70 @@ minetest.register_chatcommand("eat2x", {
 		eat2x = false
 	end
 	__eat_click_settings_cache[name] = not eat2x
+	print(dump(__eat_click_settings_cache))
         end,
 })
+
+function eat_ok (itemstack, user, pointed_thing)
+	local pt_pos = minetest.get_pointed_thing_position(pointed_thing)
+	local pname = user:get_player_name()
+	local cache = __eat_click_settings_cache
+	if cache[pname] == nil then
+		local pmeta = user:get_meta()
+		local eat2x = pmeta:get_string("conf_eat2x") or minetest.settings:get('exile_eat_doubleclick') or 'false'
+		if eat2x == 'true' then
+			eat2x = true
+		else 
+			eat2x = false
+		end
+		cache[pname] = not eat2x
+	end
+	if ( not cache[pname] ) or minimal.click_count_ready(pname, pt_pos, 2, 2) then
+		return true
+	else
+	minetest.chat_send_player(pname, S("double click to eat"))
+	end
+end
+
+function exile_eatdrink_playermade(itemstack, user, pointed_thing)
+   local imeta = itemstack:get_meta()
+   local pname = user:get_player_name()
+   local t = minetest.deserialize(imeta:get_string("eat_value"))
+   if t == nil then minetest.log("warning", pname..
+				    " ate an invalid food of type "..
+				    itemstack:get_name())
+      return
+   end
+   if eat_ok(itemstack, user, pointed_thing) then
+ 	  return HEALTH.use_item(itemstack, user, t[1], t[2], t[3], t[4], t[5], t[6])
+   end
+end
+
+function exile_eatdrink(itemstack, user, pointed_thing)
+   local name = itemstack:get_name()
+
+   if minetest.registered_aliases[name] then
+      name = minetest.registered_aliases[name]
+   end
+   if not (food_table[name] or (minetest.get_item_group(name,'edible') > 0))  then
+      minetest.chat_send_player(user:get_player_name(),
+				S("This is inedible."))
+      return
+   end
+   if eat_ok(itemstack, user, pointed_thing) then
+	   do_food_harm(user, name)
+	   local t = food_table[name]
+	   return HEALTH.use_item(itemstack, user, t[1], t[2], t[3], t[4], t[5], t[6])
+   else
+      return
+   end
+end
+
 
 -- Overrides for edible and bakable nodes
 local eat_redef = {
    on_use = function(itemstack, user, pointed_thing)
-	   local pt_pos = minetest.get_pointed_thing_position(pointed_thing)
-	   local pname = user:get_player_name()
-	   local singleclick = single_click_eat(pname,user)
-	   if singleclick or minimal.click_count_ready(pname, pt_pos, 2, 2) then
-		return exile_eatdrink(itemstack, user)
-	   else
-		minetest.chat_send_player(user:get_player_name(),
-			S("Double click to eat"))
-	   end
+		return exile_eatdrink(itemstack, user, pointed_thing)
 end}
 
 local function bake_error(pos, selfname)
@@ -178,7 +183,7 @@ function exile_add_harm(table)
 end
 
 function exile_add_food_hooks(name)
-   if food_table[name] then
+   if (minetest.get_item_group(name,'edible') > 0) or food_table[name] then
       minetest.override_item(name, eat_redef)
    end
    if bake_table[name] then
@@ -189,6 +194,14 @@ function exile_add_food_hooks(name)
    end
 end
 
+-- Add food hooks to all nodes in edible group
+minetest.register_on_mods_loaded(function()
+	for name,_ in pairs(minetest.registered_nodes) do
+		if minetest.get_item_group(name,'edible') > 0 then
+			exile_add_food_hooks(name)
+		end
+	end
+end)
 
 -- Finalized table list
 --Outputs a compilned list of all added foods to the minetest log, info level

--- a/mods/health/food.lua
+++ b/mods/health/food.lua
@@ -108,7 +108,7 @@ function exile_eatdrink(itemstack, user, pointed_thing)
    if minetest.registered_aliases[name] then
       name = minetest.registered_aliases[name]
    end
-   if not (food_table[name] or (minetest.get_item_group(name,'edible') > 0))  then
+   if not food_table[name] then
       minetest.chat_send_player(user:get_player_name(),
 				S("This is inedible."))
       return

--- a/mods/health/food.lua
+++ b/mods/health/food.lua
@@ -65,11 +65,10 @@ function exile_eatdrink(itemstack, user)
 end
 
 local __eat_click_settings_cache = {}
-local __cache_timeout = 60 -- 1 minute timeout on cache values
 function single_click_eat(pname, user)
 	local epoch = os.time()
 	local cache = __eat_click_settings_cache
-	if not (cache[pname] and cache[pname].timeout > epoch) then
+	if not cache[pname] then
 		local pmeta = user:get_meta()
 		local eat2x = pmeta:get_string("conf_eat2x") or minetest.settings:get('exile_eat_doubleclick') or 'false'
 		if eat2x == 'true' then
@@ -77,13 +76,9 @@ function single_click_eat(pname, user)
 		else 
 			eat2x = false
 		end
-		cache[pname] = {
-			timeout = epoch + __cache_timeout,
-			single_click = not eat2x,
-		}
+		cache[pname] = not eat2x
 	end
-print(dump(cache))
-	return cache[pname].single_click
+	return cache[pname]
 end
 
 minetest.register_chatcommand("eat2x", {
@@ -111,12 +106,7 @@ minetest.register_chatcommand("eat2x", {
 	else
 		eat2x = false
 	end
-
-	local epoch = os.time()
-	__eat_click_settings_cache[name] = {
-		timeout = epoch + __cache_timeout,
-		single_click = not eat2x,
-	}
+	__eat_click_settings_cache[name] = not eat2x
         end,
 })
 

--- a/mods/health/food.lua
+++ b/mods/health/food.lua
@@ -70,8 +70,8 @@ minetest.register_chatcommand("eat2x", {
 function eat_ok (itemstack, user, pointed_thing)
 	local pt_pos = minetest.get_pointed_thing_position(pointed_thing)
 	local pname = user:get_player_name()
-	local cache = __eat_click_settings_cache
-	if cache[pname] == nil then
+	local single_click = __eat_click_settings_cache
+	if single_click[pname] == nil then
 		local pmeta = user:get_meta()
 		local eat2x = pmeta:get_string("conf_eat2x") or minetest.settings:get('exile_eat_doubleclick') or 'false'
 		if eat2x == 'true' then
@@ -79,9 +79,9 @@ function eat_ok (itemstack, user, pointed_thing)
 		else 
 			eat2x = false
 		end
-		cache[pname] = not eat2x
+		single_click[pname] = not eat2x
 	end
-	if ( not cache[pname] ) or minimal.click_count_ready(pname, pt_pos, 2, 2) then
+	if ( single_click[pname] ) or minimal.click_count_ready(pname, pt_pos, 2, 2) then
 		return true
 	else
 	minetest.chat_send_player(pname, S("double click to eat"))

--- a/mods/health/food.lua
+++ b/mods/health/food.lua
@@ -67,7 +67,15 @@ end
 -- Overrides for edible and bakable nodes
 local eat_redef = {
    on_use = function(itemstack, user, pointed_thing)
-      return exile_eatdrink(itemstack, user)
+	   local pt_pos = minetest.get_pointed_thing_position(pointed_thing)
+	   local pname = user:get_player_name()
+	   if minimal.click_count_ready(pname, pt_pos, 2, 2) then
+		return exile_eatdrink(itemstack, user)
+	   else
+		minetest.chat_send_player(user:get_player_name(),
+			S("Double click to eat"))
+	   end
+
 end}
 
 local function bake_error(pos, selfname)

--- a/mods/health/food.lua
+++ b/mods/health/food.lua
@@ -64,18 +64,74 @@ function exile_eatdrink(itemstack, user)
    return HEALTH.use_item(itemstack, user, t[1], t[2], t[3], t[4], t[5], t[6])
 end
 
+local __eat_click_settings_cache = {}
+local __cache_timeout = 60 -- 1 minute timeout on cache values
+function single_click_eat(pname, user)
+	local epoch = os.time()
+	local cache = __eat_click_settings_cache
+	if not (cache[pname] and cache[pname].timeout > epoch) then
+		local pmeta = user:get_meta()
+		local eat2x = pmeta:get_string("conf_eat2x") or minetest.settings:get('exile_eat_doubleclick') or 'false'
+		if eat2x == 'true' then
+			eat2x = true
+		else 
+			eat2x = false
+		end
+		cache[pname] = {
+			timeout = epoch + __cache_timeout,
+			single_click = not eat2x,
+		}
+	end
+print(dump(cache))
+	return cache[pname].single_click
+end
+
+minetest.register_chatcommand("eat2x", {
+        params = "true or false",
+        description = "Toggles double-click to eat",
+        func = function(name, param)
+        local player = minetest.get_player_by_name(name)
+        local meta = player:get_meta()
+        local eat2x=meta:get_string("conf_eat2x") or minetest.settings:get("exile_eat_doubleclick") or "false"
+        if param and param ~="" then
+                local wlist = "/eat2x:\n"..
+                "Toggle double-click to eat"
+                return false, wlist
+        end
+        if eat2x == "true" then
+                eat2x = "false"
+        else
+                eat2x = "true"
+        end
+	
+        meta:set_string("conf_eat2x", eat2x)
+	minetest.chat_send_player(name,"Double-Click to eat: "..eat2x)
+	if eat2x == 'true' then
+		eat2x = true
+	else
+		eat2x = false
+	end
+
+	local epoch = os.time()
+	__eat_click_settings_cache[name] = {
+		timeout = epoch + __cache_timeout,
+		single_click = not eat2x,
+	}
+        end,
+})
+
 -- Overrides for edible and bakable nodes
 local eat_redef = {
    on_use = function(itemstack, user, pointed_thing)
 	   local pt_pos = minetest.get_pointed_thing_position(pointed_thing)
 	   local pname = user:get_player_name()
-	   if minimal.click_count_ready(pname, pt_pos, 2, 2) then
+	   local singleclick = single_click_eat(pname,user)
+	   if singleclick or minimal.click_count_ready(pname, pt_pos, 2, 2) then
 		return exile_eatdrink(itemstack, user)
 	   else
 		minetest.chat_send_player(user:get_player_name(),
 			S("Double click to eat"))
 	   end
-
 end}
 
 local function bake_error(pos, selfname)

--- a/mods/nodes_nature/liquids.lua
+++ b/mods/nodes_nature/liquids.lua
@@ -207,9 +207,10 @@ minetest.register_node("nodes_nature:snow", {
 	},
 	temp_effect = -2,
 	temp_effect_max = 0,
-	groups = {crumbly = 3, falling_node = 1, temp_effect = 1, temp_pass = 1, puts_out_fire = 1, fall_damage_add_percent = -25},
+	groups = {crumbly = 3, falling_node = 1, temp_effect = 1, temp_pass = 1, 
+		puts_out_fire = 1, fall_damage_add_percent = -25,
+		edible = 1},
 	sounds = nodes_nature.node_sound_snow_defaults(),
-	on_use = exile_eatdrink,
 	on_rightclick = function (pos,node,clicker,itemstack,pointed_thing)
 		return minimal.slabs_combine(pos,node,itemstack,'nodes_nature:snow_block')
 	end,
@@ -221,9 +222,11 @@ minetest.register_node("nodes_nature:snow_block", {
 	stack_max = minimal.stack_max_bulky,
 	temp_effect = -4,
 	temp_effect_max = 0,
-	groups = {crumbly = 3, falling_node = 1, temp_effect = 1, puts_out_fire = 1, cools_lava = 1, fall_damage_add_percent = -50},
+	groups = {crumbly = 3, falling_node = 1, temp_effect = 1, 
+		puts_out_fire = 1, cools_lava = 1, fall_damage_add_percent = -50,
+		edible = 1,
+	},
 	sounds = nodes_nature.node_sound_snow_defaults(),
-	on_use = exile_eatdrink
 })
 
 

--- a/mods/tech/cooking_pot.lua
+++ b/mods/tech/cooking_pot.lua
@@ -67,7 +67,7 @@ minetest.register_craftitem("tech:soup", {
 	inventory_image = "tech_soup.png",
 	stack_max = minimal.stack_max_medium,
 	on_use = function(itemstack, user, pointed_thing)
-	   return exile_eatdrink_playermade(itemstack, user)
+	   return exile_eatdrink_playermade(itemstack, user, pointed_thing)
 	end
 })
 

--- a/mods/tech/plant_crafts.lua
+++ b/mods/tech/plant_crafts.lua
@@ -120,7 +120,7 @@ minetest.register_node("tech:maraka_bread", {
 		type = "fixed",
 		fixed = {-0.3, -0.5, -0.3, 0.3, -0.3, 0.3},
 	},
-	groups = {crumbly = 3, dig_immediate = 3, temp_pass = 1, heatable = 80},
+	groups = {crumbly = 3, dig_immediate = 3, temp_pass = 1, heatable = 80, edible = 1},
 	sounds = nodes_nature.node_sound_dirt_defaults(),
 })
 
@@ -137,7 +137,7 @@ minetest.register_node("tech:maraka_bread_cooked", {
 		type = "fixed",
 		fixed = {-0.28, -0.5, -0.28, 0.28, -0.32, 0.28},
 	},
-	groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, temp_pass = 1, heatable = 80},
+	groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, temp_pass = 1, heatable = 80, edible = 1},
 	sounds = nodes_nature.node_sound_dirt_defaults(),
 })
 
@@ -154,13 +154,9 @@ minetest.register_node("tech:maraka_bread_burned", {
     type = "fixed",
     fixed = {-0.28, -0.5, -0.28, 0.28, -0.32, 0.28},
   },
-  groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1},
+  groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1, edible = 1},
   sounds = nodes_nature.node_sound_dirt_defaults(),
 })
-exile_add_food_hooks("tech:maraka_bread")
-exile_add_food_hooks("tech:maraka_bread_cooked")
-exile_add_food_hooks("tech:maraka_bread_burned")
-
 
 -----------
 --Anperla
@@ -175,7 +171,7 @@ minetest.register_node("tech:peeled_anperla", {
     type = "fixed",
     fixed = {-0.15, -0.5, -0.15,  0.15, -0.35, 0.15},
   },
-	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, temp_pass = 1, heatable = 70},
+	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, temp_pass = 1, heatable = 70, edible = 1},
 	sounds = nodes_nature.node_sound_dirt_defaults(),
 })
 
@@ -190,7 +186,7 @@ minetest.register_node("tech:peeled_anperla_burned", {
     type = "fixed",
     fixed = {-0.15, -0.5, -0.15,  0.15, -0.35, 0.15},
   },
-	groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1},
+	groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1, edible = 1},
 	sounds = nodes_nature.node_sound_dirt_defaults(),
 })
 
@@ -205,13 +201,9 @@ minetest.register_node("tech:peeled_anperla_cooked", {
     type = "fixed",
     fixed = {-0.15, -0.5, -0.15,  0.15, -0.35, 0.15},
   },
-	groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, heatable = 70,  temp_pass = 1},
+	groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, heatable = 70,  temp_pass = 1, edible = 1},
 	sounds = nodes_nature.node_sound_dirt_defaults(),
 })
-exile_add_food_hooks("tech:peeled_anperla")
-exile_add_food_hooks("tech:peeled_anperla_cooked")
-exile_add_food_hooks("tech:peeled_anperla_burned")
-
 
 --mash (a way to bulk cook tubers - 6 at once)
 minetest.register_node("tech:mashed_anperla", {
@@ -225,7 +217,7 @@ minetest.register_node("tech:mashed_anperla", {
     type = "fixed",
     fixed = {-6/16, -0.5, -6/16, 6/16, 1/16, 6/16},
   },
-	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, temp_pass = 1, heatable = 70},
+	groups = {snappy = 3, falling_node = 1, dig_immediate = 3, temp_pass = 1, heatable = 70, edible = 1},
 	sounds = nodes_nature.node_sound_dirt_defaults(),
 })
 
@@ -240,7 +232,7 @@ minetest.register_node("tech:mashed_anperla_cooked", {
     type = "fixed",
     fixed = {-5/16, -0.5, -5/16, 5/16, -1/16, 5/16},
   },
-	groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, heatable = 70,  temp_pass = 1},
+	groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, heatable = 70,  temp_pass = 1, edible = 1},
 	sounds = nodes_nature.node_sound_dirt_defaults(),
 })
 
@@ -255,12 +247,9 @@ minetest.register_node("tech:mashed_anperla_burned", {
     type = "fixed",
     fixed = {-5/16, -0.5, -5/16, 5/16, -1/16, 5/16},
   },
-  groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1},
+  groups = {crumbly = 3, falling_node = 1, dig_immediate = 3, flammable = 1,  temp_pass = 1, edible = 1},
   sounds = nodes_nature.node_sound_dirt_defaults(),
 })
-exile_add_food_hooks("tech:mashed_anperla")
-exile_add_food_hooks("tech:mashed_anperla_cooked")
-exile_add_food_hooks("tech:mashed_anperla_burned")
 
 ------------------------------------------
 --Vegetable Oils


### PR DESCRIPTION
chat command /eat2x to toggle
Server settings option of exile_eat_doubleclick ; true/false
player meta of conf_eat2x : true/false
double click defined as 2 clicks in 2 seconds on the same pointed_thing pos
Keeps a local cache of the players settings for 1 minutes to reduce load of checking config options