### PR TITLE
Fix to allow cobble to call on_rightclick of item right clicked on

### DIFF
--- a/mods/nodes_nature/rock.lua
+++ b/mods/nodes_nature/rock.lua
@@ -10,6 +10,10 @@ rock_list  = rock_list
 
 function cobble_on_place(itemstack, placer, pointed_thing, name)
 	local pt_pos = minetest.get_pointed_thing_position(pointed_thing)
+	local pt_node=minetest.get_node(pt_pos)
+	if pt_node and  minetest.registered_nodes[pt_node.name].on_rightclick then
+		return minetest.registered_nodes[pt_node.name].on_rightclick(pt_pos,pt_node,placer,itemstack,pointed_thing)
+	end
 	local cobble_nr = math.random(1,3)
 	local param2 = math.random(0,3)
 	local place_item = ItemStack("nodes_nature:"..name.."_cobble"..cobble_nr)


### PR DESCRIPTION
Looks like it auto closed the old PR so here's a fresh one that's correct